### PR TITLE
Add support for getting clients in a given room

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function Adapter(nsp){
  * Inherits from `EventEmitter`.
  */
 
-Adapter.prototype.__proto__ = Emitter.prototype;
+Adapter.prototype = Object.create(Emitter.prototype);
 
 /**
  * Adds a socket from a room.

--- a/index.js
+++ b/index.js
@@ -91,10 +91,23 @@ Adapter.prototype.delAll = function(id, fn){
  * @api public
  */
 Adapter.prototype.clients = function(room, fn){
+  // One argument
   if(!fn){
-    return;
+    if(typeof(room) !== 'function'){
+      return;
+    }
+    fn = room;
+    room = null;
   }
-  process.nextTick(fn.bind(null, null, Object.keys(this.rooms[room] || [])));
+
+  var result;
+  if(room === null){
+    result = Object.keys(this.sids || []);
+  }
+  else{
+    result = Object.keys(this.rooms[room] || []);
+  }
+  process.nextTick(fn.bind(null, null, result));
 };
 
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,21 @@ Adapter.prototype.delAll = function(id, fn){
   delete this.sids[id];
 };
 
+
+/**
+ * Get all clients in room.
+ *
+ * @param {String} room id
+ * @api public
+ */
+Adapter.prototype.clients = function(room, fn){
+  if(!fn){
+    return;
+  }
+  process.nextTick(fn.bind(null, null, Object.keys(this.rooms[room] || [])));
+};
+
+
 /**
  * Broadcasts a packet.
  *

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,91 @@
+var expect = require('expect.js');
+var async = require('async');
+var Adapter = require('../index.js');
+
+describe('socket.io-adapter', function(){
+  var adapter;
+  describe('Adapter', function(){
+    it('should construct the adapter', function(){
+      adapter = new Adapter('test');
+      expect(adapter).to.be.an(Adapter);
+    });
+  });
+  describe('add', function(){
+    it('should add a socket to a room', function(){
+      var room = 'a';
+      var sid = '1';
+      adapter.add(sid, room, function(){
+        expect(adapter.sids).to.be.an('object');
+        expect(adapter.sids[sid]).to.be.an('object');
+        expect(adapter.sids[sid][room]).to.equal(true);
+        expect(adapter.rooms[room]).to.be.an('object');
+        expect(adapter.rooms[room][sid]).to.equal(true);
+      });
+    });
+  });
+  describe('del', function(){
+    it('should remove a socket from aroom', function(){
+      var room = 'a';
+      var sid = '1';
+      adapter.del(sid, room);
+      expect(adapter.sids[sid]).to.not.contain(room);
+      expect(adapter.rooms[room]).to.not.contain(room);
+    });
+  });
+  describe('delAll', function(){
+    var sid = 'a';
+    var rooms = [];
+
+    before(function(done){
+      //Clear rooms and sockets
+      adapter.sids = {};
+      adapter.rooms = {};
+
+      //Add the socket to multiple rooms
+      async.times(10, function(n, next){
+        rooms.push(n);
+        adapter.add(sid, n, function(){
+          next();
+        });
+      }, done);
+    });
+
+    it('should remove a socket from all rooms', function(done){
+      var rooms = Object.keys(adapter.rooms);
+      var i;
+      for(i=0; i<rooms.length; ++i){
+        expect(adapter.rooms[rooms[i]]).to.have.key(sid);
+      }
+      adapter.delAll(sid);
+      for(i=0; i<rooms.length; ++i){
+        expect(adapter.rooms[rooms[i]]).to.not.have.key(sid);
+      }
+      done();
+    });
+  });
+  describe('clients', function(){
+    var room = 'a';
+    var sids = [];
+
+    before(function(done){
+      //Clear rooms and sockets
+      adapter.sids = {};
+      adapter.rooms = {};
+
+      //Add the socket to multiple rooms
+      async.times(10, function(n, next){
+        n = n.toString();
+        sids.push(n);
+        adapter.add(n, room, function(){
+          next();
+        });
+      }, done);
+    });
+    it('should get all clients in a room', function(done){
+      adapter.clients(room, function(err, clients){
+        expect(clients).to.only.have.keys(sids);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
I added a function in the base adapter for getting ids of connected clients in a room.
The function is async to allow simple replacement with the redis adapter (see pull request in socket.io-redis):
(Automattic/socket.io-redis#15)

Also added mocha tests for all functions in adapter.js