### PR TITLE
Do not set key/value pairs on arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ Adapter.prototype.__proto__ = Emitter.prototype;
 Adapter.prototype.add = function(id, room, fn){
   this.sids[id] = this.sids[id] || {};
   this.sids[id][room] = true;
-  this.rooms[room] = this.rooms[room] || [];
+  this.rooms[room] = this.rooms[room] || {};
   this.rooms[room][id] = true;
   if (fn) process.nextTick(fn.bind(null, null));
 };


### PR DESCRIPTION
New rooms should be created as objects, not arrays since they're being treated as an object. Using an array leads one to believe that they may use the length property to discover how many users are in the room.
