### PR TITLE
changed socket.io-parser dependency to version 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "",
   "dependencies": {
     "debug": "1.0.2",
-    "socket.io-parser": "2.2.0",
+    "socket.io-parser": "2.2.1",
     "object-keys": "1.0.1"
   }
 }


### PR DESCRIPTION
the socket.io-parser dependency prior to version 2.2.1 had a dependency to [component/emitter](https://github.com/component/emitter) using an URL ([see here](https://github.com/Automattic/socket.io-parser/blob/2.2.0/package.json#L12).

This broke any installation of [socket.io](https://github.com/Automattic/socket.io) in an secured network (no connection to the internet, using only a local NPM replica). In fact there is a [similar and related issue for **engine.io-client**](https://github.com/Automattic/engine.io-client/issues/348)

socket.io-parser in version 2.2.1 or greater describe the [dependency through a NPM package](https://github.com/Automattic/socket.io-parser/blob/2.2.1/package.json#L12)

There are no tests for this package, so I couldn't really check if it still works. I only looked at the **component/emitter** commits and judged that it should work...
