### PR TITLE
Bump parser version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "",
   "dependencies": {
     "debug": "1.0.2",
-    "socket.io-parser": "2.2.0",
+    "socket.io-parser": "2.2.2",
     "object-keys": "1.0.1"
   }
 }


### PR DESCRIPTION
Fixes `.gitignore` issue with `component-emitter`.
