### PR TITLE
Update “debug” to avoid vulnerability in “ms”

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "description": "",
   "dependencies": {
-    "debug": "1.0.2",
+    "debug": "^2.2.0",
     "socket.io-parser": "2.2.2"
   }
 }


### PR DESCRIPTION
[Package `ms` is vulnerable to DoS attacks](https://nodesecurity.io/advisories/46). The issue was fixed in `v0.7.1`.

Package `debug` was updated accordingly in `v2.2.0`.

This PR updates the required version of `debug` ([Node Security tools](https://www.npmjs.com/package/nsp) will complain and fail until this is fixed).