### PR TITLE
bump debug to ~2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,5 @@
     "type": "git",
     "url": "git://github.com/Automattic/socket.io-adapter.git"
   },
-  "description": "",
-  "dependencies": {
-    "debug": "^2.6.4"
-  }
+  "description": ""
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "description": "",
   "dependencies": {
-    "debug": "2.3.3"
+    "debug": "^2.6.4"
   }
 }


### PR DESCRIPTION
Please bump debug to `~2.6.4`, the same version used by (almost) all the other `github.com/socketio/*` packages.

The current version of debug that was pinned is reported as having a sec vulnerability by snyk via its dependency `ms`. It doesn't effect socket.io, but every user of socket.io has to figure that out themselves right now.

It allows debug to be de-duplicated and the install tree flattened (a minor convenience).

I would also strongly suggest moving to `^2.x`, because `debug` is a very small package, with a small and  easy to manage API surface and maintainers who are very, very careful about semver and who will not introduce breaking changes in minors. In this PR, though, I just updated this to use the exact same debug dep spec you use elsewhere.