### PR TITLE
Allow passthrough of the "loopback" flag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ Adapter.prototype.broadcast = function(packet, opts){
   var flags = opts.flags || {};
   var packetOpts = {
     preEncoded: true,
+    loopback: flags.loopback,
     volatile: flags.volatile,
     compress: flags.compress
   };


### PR DESCRIPTION
This is required by https://github.com/socketio/socket.io/pull/3235, so that the `loopback` flag is propagated through the adapter.