### PR TITLE
bugfix: fix memory leak when leave a room after socket close

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,12 @@ Adapter.prototype.addAll = function(id, rooms, fn){
  */
 
 Adapter.prototype.del = function(id, room, fn){
-  this.sids[id] = this.sids[id] || {};
-  delete this.sids[id][room];
-  if (this.rooms.hasOwnProperty(room)) {
-    this.rooms[room].del(id);
-    if (this.rooms[room].length === 0) delete this.rooms[room];
+  if (this.sids[id]) {
+    delete this.sids[id][room];
+    if (this.rooms.hasOwnProperty(room)) {
+      this.rooms[room].del(id);
+      if (this.rooms[room].length === 0) delete this.rooms[room];
+    }
   }
 
   if (fn) process.nextTick(fn.bind(null, null));

--- a/index.js
+++ b/index.js
@@ -74,12 +74,11 @@ Adapter.prototype.addAll = function(id, rooms, fn){
  */
 
 Adapter.prototype.del = function(id, room, fn){
-  if (this.sids[id]) {
-    delete this.sids[id][room];
-    if (this.rooms.hasOwnProperty(room)) {
-      this.rooms[room].del(id);
-      if (this.rooms[room].length === 0) delete this.rooms[room];
-    }
+  if (this.sids[id]) delete this.sids[id][room];
+
+  if (this.rooms.hasOwnProperty(room)) {
+    this.rooms[room].del(id);
+    if (this.rooms[room].length === 0) delete this.rooms[room];
   }
 
   if (fn) process.nextTick(fn.bind(null, null));


### PR DESCRIPTION
We found socket.io may leak memory when we leave a room after socket closed. I see `socket.io-adapter` will leave all room first before closing a socket, but it's implicit.

So, I think there is no necessity to create new `sids` in `Adapter.prototype.del` function. Let me know if you have any suggestions.