### PR TITLE
Fix #65: allow excluding all sockets in a room

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -138,6 +138,20 @@ export class Adapter extends EventEmitter {
     packet.nsp = this.nsp.name;
     const encodedPackets = this.encoder.encode(packet);
 
+    // Allow ids in `except` to be room ids.
+    if (except.size > 0) {
+      const exclude = except;
+      except = new Set(except);
+      for (const id of exclude) {
+        if (!this.rooms.has(id)) continue;
+        for (const sid of this.rooms.get(id)) {
+          if (sid !== id) {
+            except.add(sid);
+          }
+        }
+      }
+    }
+
     if (rooms.size) {
       for (const room of rooms) {
         if (!this.rooms.has(room)) continue;
@@ -152,20 +166,6 @@ export class Adapter extends EventEmitter {
         }
       }
     } else {
-      // Allow ids in `except` to be room ids.
-      if (except.size > 0) {
-        const exclude = except;
-        except = new Set(except);
-        for (const id of exclude) {
-          if (!this.rooms.has(id)) continue;
-          for (const sid of this.rooms.get(id)) {
-            if (sid !== id) {
-              except.add(sid);
-            }
-          }
-        }
-      }
-
       for (const [id] of this.sids) {
         if (except.has(id)) continue;
         const socket = this.nsp.sockets.get(id);

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,39 @@ describe("socket.io-adapter", () => {
     expect(ids).to.eql(["s2"]);
   });
 
+  it("should exclude sockets in specific rooms when broadcasting to rooms", () => {
+    let ids = [];
+    function socket(id) {
+      return [
+        id,
+        {
+          id,
+          packet() {
+            ids.push(id);
+          }
+        }
+      ];
+    }
+    const nsp = {
+      server: {
+        encoder: {
+          encode() {}
+        }
+      },
+      sockets: new Map([socket("s1"), socket("s2"), socket("s3")])
+    };
+    const adapter = new Adapter(nsp);
+    adapter.addAll("s1", new Set(["r1", "r2"]));
+    adapter.addAll("s2", new Set(["r2"]));
+    adapter.addAll("s3", new Set(["r1"]));
+
+    adapter.broadcast([], {
+      rooms: new Set(["r1"]),
+      except: new Set(["r2"])
+    });
+    expect(ids).to.eql(["s3"]);
+  });
+
   describe("events", () => {
     it("should emit a 'create-room' event", done => {
       const adapter = new Adapter({ server: { encoder: null } });

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,39 @@ describe("socket.io-adapter", () => {
     expect(adapter.socketRooms("s4")).to.be(undefined);
   });
 
+  it("should exclude sockets in specific rooms when broadcasting", () => {
+    let ids = [];
+    function socket(id) {
+      return [
+        id,
+        {
+          id,
+          packet() {
+            ids.push(id);
+          }
+        }
+      ];
+    }
+    const nsp = {
+      server: {
+        encoder: {
+          encode() {}
+        }
+      },
+      sockets: new Map([socket("s1"), socket("s2"), socket("s3")])
+    };
+    const adapter = new Adapter(nsp);
+    adapter.addAll("s1", new Set(["r1"]));
+    adapter.addAll("s2", new Set());
+    adapter.addAll("s3", new Set(["r1"]));
+
+    adapter.broadcast([], {
+      rooms: new Set(),
+      except: new Set(["r1"])
+    });
+    expect(ids).to.eql(["s2"]);
+  });
+
   describe("events", () => {
     it("should emit a 'create-room' event", done => {
       const adapter = new Adapter({ server: { encoder: null } });


### PR DESCRIPTION
This PR adds a fix for #65 which allows excluding all sockets in a specific room when broadcasting.