### PR TITLE
feat: add broadcast-packet send-socket-packet events

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,6 +133,8 @@ export class Adapter extends EventEmitter {
     };
 
     packet.nsp = this.nsp.name;
+    this.emit("broadcast-packet", packet, basePacketOpts);
+
     const encodedPackets = this.encoder.encode(packet);
 
     const packetOpts = encodedPackets.map(encodedPacket => {
@@ -147,6 +149,7 @@ export class Adapter extends EventEmitter {
     });
 
     this.apply(opts, socket => {
+      this.emit("send-socket-packet", socket, packet);
       for (let i = 0; i < encodedPackets.length; i++) {
         socket.client.writeToEngine(encodedPackets[i], packetOpts[i]);
       }


### PR DESCRIPTION
Adding new events on adapter instance to be able to add aspects like logger or metric to events which are emitter by socket.io-(*)-emitters.

Could you please point me where could I update [that page](https://socket.io/docs/v4/adapter/) with new events if you fine with that change.