### PR TITLE
Add event broadcast middleware

### DIFF
--- a/lib/contrib/immutable.ts
+++ b/lib/contrib/immutable.ts
@@ -1,0 +1,24 @@
+//With thanks to https://stackoverflow.com/a/58993872/12614999
+
+type ImmutablePrimitive =
+  | undefined
+  | null
+  | boolean
+  | string
+  | number
+  | Function;
+
+export type Immutable<T> = T extends ImmutablePrimitive
+  ? T
+  : T extends Array<infer U>
+  ? ImmutableArray<U>
+  : T extends Map<infer K, infer V>
+  ? ImmutableMap<K, V>
+  : T extends Set<infer M>
+  ? ImmutableSet<M>
+  : ImmutableObject<T>;
+
+export type ImmutableArray<T> = ReadonlyArray<Immutable<T>>;
+export type ImmutableMap<K, V> = ReadonlyMap<Immutable<K>, Immutable<V>>;
+export type ImmutableSet<T> = ReadonlySet<Immutable<T>>;
+export type ImmutableObject<T> = { readonly [K in keyof T]: Immutable<T[K]> };

--- a/test/index.ts
+++ b/test/index.ts
@@ -91,10 +91,13 @@ describe("socket.io-adapter", () => {
     adapter.addAll("s2", new Set());
     adapter.addAll("s3", new Set(["r1"]));
 
-    adapter.broadcast([], {
-      rooms: new Set(),
-      except: new Set(["r1"]),
-    });
+    adapter.broadcast(
+      { type: 2 },
+      {
+        rooms: new Set(),
+        except: new Set(["r1"]),
+      }
+    );
     expect(ids).to.eql(["s2"]);
   });
 
@@ -133,10 +136,13 @@ describe("socket.io-adapter", () => {
     adapter.addAll("s2", new Set(["r2"]));
     adapter.addAll("s3", new Set(["r1"]));
 
-    adapter.broadcast([], {
-      rooms: new Set(["r1"]),
-      except: new Set(["r2"]),
-    });
+    adapter.broadcast(
+      { type: 2 },
+      {
+        rooms: new Set(["r1"]),
+        except: new Set(["r2"]),
+      }
+    );
     expect(ids).to.eql(["s3"]);
   });
 
@@ -176,10 +182,13 @@ describe("socket.io-adapter", () => {
     adapter.addAll("s2", new Set());
     adapter.addAll("s3", new Set());
 
-    adapter.broadcast([], {
-      rooms: new Set(),
-      except: new Set(),
-    });
+    adapter.broadcast(
+      { type: 2 },
+      {
+        rooms: new Set(),
+        except: new Set(),
+      }
+    );
   });
 
   describe("utility methods", () => {


### PR DESCRIPTION
This is part of the solution for [#4709](https://github.com/socketio/socket.io/issues/4709)

# What I did here
- Add some more types
    - Replaced some of the `unknown` and `any`
    - I've taken some of the types of the socket.io repo, not sure if you'd rather add a dependency and import them
- Added a public `useEventBroadcast` method on the adapter to register a middleware
- The middlewares
    - are executed for directly broadcasted events
    - and events stored in the session-recovery list to not leak anything upon reconnect that would have been modified otherwise.
    - I've added a deep-immutable type implementation, so that middlewares won't mutate the data for other sockets. Again, I'm not sure whether you'd prefer to use a library like `ts-essentials` for that.
- I've combined the mostly identical code of `broadcast` and `broadcastWithAck`

-----

Is this implementation something that you can see getting merged?

If so, I'd continue adding tests and also prepare the integration into the socket.io main repo, which would need to receive a method to register the middleware with the adapter.