### PR TITLE
feat(?): Eager fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,16 @@
 name: CI
 
 on:
-  push:
   pull_request:
-  schedule:
-    - cron: '0 0 * * 0'
-
-permissions:
-  contents: read
 
 jobs:
   test-node:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
 
     strategy:
       matrix:
         node-version:
-          - 14
           - 20
 
     steps:
@@ -31,12 +24,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      # the "override" keyword was added in typescript@4.5.0
-      # else, users can go down to typescript@3.8.x ("import type")
-      - name: Install TypeScript 4.5
-        run: npm i typescript@4.5
-        if: ${{ matrix.node-version == '14' }}
 
       - name: Run tests
         run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socket.io-adapter",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socket.io-adapter",
-      "version": "2.5.2",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.3.4",


### PR DESCRIPTION
Add eager fetching option to cluster config. Eager fetching causes requests to return a result even if some of the cluster nodes didn't respond.

remove ids of dead nodes from pending requests
add initialization delay to account for time that it takes nodes to respond with heartbeat